### PR TITLE
Event listener on to once

### DIFF
--- a/src/Moderator.js
+++ b/src/Moderator.js
@@ -58,7 +58,7 @@ module.exports = class Moderator extends EventEmitter {
             member.roles.add(searchMutes.muteRoleID);
         })
 
-        client.on('ready', () => {
+        client.once('ready', () => {
             this._checkConstructorOptions();
 
             this._checkMutes();


### PR DESCRIPTION
- Frees up an event listener
- Prevents random bugs as the ready event can fire multiple times